### PR TITLE
feat: auto-rotate actions, image hotspots, and camera marker update

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,6 +87,33 @@
         transition-property: transform, opacity;
       }
 
+      .hotspot.has-image {
+        background-color: transparent;
+        border: none;
+        border-radius: 0;
+        width: auto;
+        height: auto;
+      }
+
+      .hotspot.has-image:not([data-visible]) {
+        background-color: transparent;
+        border: none;
+      }
+
+      .hotspot-image {
+        display: block;
+        width: var(--hotspot-size, 20px);
+        height: auto;
+        pointer-events: none;
+        user-select: none;
+        -webkit-user-drag: none;
+      }
+
+      .hotspot.has-image:not([data-visible]) > .hotspot-image {
+        opacity: var(--min-hotspot-opacity, 0.25);
+        transform: none;
+      }
+
       .annotation {
         --annotation-color: black;
         --annotation-background-color: white;

--- a/public/pandasuite.json
+++ b/public/pandasuite.json
@@ -61,6 +61,21 @@
         "hideSystemId": true,
         "params": [
           {
+            "id": "image",
+            "name": "Image",
+            "locale_name": {
+              "fr_FR": "Image"
+            },
+            "type": "Image",
+            "bindable": true,
+            "sizes": ["128w", "256w", "512w"],
+            "hidden": "marker.type != 'hotspot'",
+            "description": "Custom image displayed instead of the colored dot. Sized by the marker size, with its aspect ratio preserved.",
+            "locale_description": {
+              "fr_FR": "Image personnalisée affichée à la place du point coloré. Dimensionnée par la taille du marqueur, ratio conservé."
+            }
+          },
+          {
             "id": "color",
             "name": "Color",
             "locale_name": {
@@ -69,10 +84,10 @@
             "type": "Color",
             "value": "#3b82f6",
             "bindable": true,
-            "hidden": "marker.type != 'hotspot'",
-            "description": "Color of the hotspot marker dot on the 3D model.",
+            "hidden": "marker.type != 'hotspot' || marker.image",
+            "description": "Color of the hotspot marker dot on the 3D model. Hidden when an image is set.",
             "locale_description": {
-              "fr_FR": "Couleur du point de marqueur sur le modèle 3D."
+              "fr_FR": "Couleur du point de marqueur sur le modèle 3D. Masqué quand une image est définie."
             }
           },
           {
@@ -91,9 +106,9 @@
             },
             "bindable": true,
             "hidden": "marker.type != 'hotspot'",
-            "description": "Size in pixels of the hotspot marker dot.",
+            "description": "Size in pixels of the hotspot — the dot diameter, or the image width.",
             "locale_description": {
-              "fr_FR": "Taille en pixels du point de marqueur."
+              "fr_FR": "Taille en pixels du marqueur — diamètre du point, ou largeur de l'image."
             }
           },
           {
@@ -197,6 +212,26 @@
             "description": "Text color of the annotation popup.",
             "locale_description": {
               "fr_FR": "Couleur du texte de la popup d'annotation."
+            }
+          },
+          {
+            "id": "updateCameraMarker",
+            "name": "Marker data",
+            "locale_name": {
+              "fr_FR": "Données du marqueur"
+            },
+            "editorControl": {
+              "type": "button",
+              "action_id": "updateCameraMarker",
+              "name": "Update",
+              "locale_name": {
+                "fr_FR": "Mettre à jour"
+              }
+            },
+            "hidden": "marker.type == 'hotspot'",
+            "description": "Re-capture the current camera view into this camera marker.",
+            "locale_description": {
+              "fr_FR": "Ré-enregistre la vue caméra actuelle dans ce marqueur."
             }
           }
         ]
@@ -878,6 +913,28 @@
       "description": "Reset the camera to its default position and orientation.",
       "locale_description": {
         "fr_FR": "Réinitialiser la caméra à sa position et orientation par défaut."
+      }
+    },
+    {
+      "id": "startAutoRotate",
+      "name": "Start auto-rotate",
+      "locale_name": {
+        "fr_FR": "Démarrer la rotation auto"
+      },
+      "description": "Start automatic rotation of the model and keep it rotating until stopped.",
+      "locale_description": {
+        "fr_FR": "Démarrer la rotation automatique du modèle et la maintenir jusqu'à l'arrêt."
+      }
+    },
+    {
+      "id": "stopAutoRotate",
+      "name": "Stop auto-rotate",
+      "locale_name": {
+        "fr_FR": "Arrêter la rotation auto"
+      },
+      "description": "Stop automatic rotation and keep it stopped (it won't resume on its own).",
+      "locale_description": {
+        "fr_FR": "Arrêter la rotation automatique et la garder arrêtée (elle ne reprend pas toute seule)."
       }
     },
     {

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,8 @@ import {
 let properties = null;
 let markers = null;
 let lastMarker = null;
+let selectedCameraMarkerId = null;
+let autoRotateOverride = null;
 let hasLoaded = false;
 let lastAnimationName = null;
 let lastAppendAnimationPayload = null;
@@ -374,12 +376,7 @@ function myInit(update) {
     modelViewer.removeAttribute('ar');
   }
 
-  if (properties.autoRotate) {
-    modelViewer.setAttribute('auto-rotate', true);
-    modelViewer.setAttribute('auto-rotate-delay', properties.autoRotateDelay);
-  } else {
-    modelViewer.removeAttribute('auto-rotate');
-  }
+  applyAutoRotate();
 
   if (properties.arMode && properties.arModeIOS) {
     const arModelUrl = `${PandaBridge.resolvePath('assets.zip', './')}${
@@ -410,10 +407,24 @@ function myInit(update) {
   }
 }
 
+// Mirror of the `sizes` on the hotspot `image` param in public/pandasuite.json:
+// the studio builds an `<N>w` srcset per entry; resolveImagePath looks them up by
+// that exact key. Keep the two lists in sync.
+const HOTSPOT_IMG_SIZES = [128, 256, 512];
+
+// Smallest declared width >= the displayed width * dpr, clamped to the largest.
+// Returns the srcset key (e.g. "256w") for PandaBridge.resolveImagePath.
+function pickHotspotImageSize(widthPx) {
+  const target = (Number(widthPx) || 0) * (window.devicePixelRatio || 1);
+  const match = HOTSPOT_IMG_SIZES.find((s) => s >= target);
+  return `${match || HOTSPOT_IMG_SIZES[HOTSPOT_IMG_SIZES.length - 1]}w`;
+}
+
 function createUpdateHotspot({
   position,
   normal,
   id,
+  image,
   color,
   size,
   minOpacity,
@@ -454,9 +465,37 @@ function createUpdateHotspot({
     }
   };
 
+  // Render a custom image inside the hotspot instead of the dot. The <img> sizes
+  // itself (width = --hotspot-size, height auto), so the aspect ratio is kept
+  // with no preload. An absent/unresolved image reverts the marker to the dot.
+  const applyImage = (hotspot) => {
+    const url = image
+      ? PandaBridge.resolveImagePath(image, pickHotspotImageSize(size))
+      : null;
+    let img = hotspot.querySelector('.hotspot-image');
+
+    if (url) {
+      if (!img) {
+        img = document.createElement('img');
+        img.classList.add('hotspot-image');
+        hotspot.insertBefore(img, hotspot.firstChild);
+      }
+      if (img.getAttribute('src') !== url) {
+        img.setAttribute('src', url);
+      }
+      hotspot.classList.add('has-image');
+    } else {
+      if (img) {
+        img.remove();
+      }
+      hotspot.classList.remove('has-image');
+    }
+  };
+
   if (modelViewer.queryHotspot(hotspotName)) {
     const hotspot = modelViewer.querySelector(`[slot="${hotspotName}"]`);
     styleForHotspot(hotspot);
+    applyImage(hotspot);
 
     modelViewer.updateHotspot({
       position: `${position.x}m ${position.y}m ${position.z}m`,
@@ -491,6 +530,7 @@ function createUpdateHotspot({
     hotspot.setAttribute('data-visibility-attribute', 'visible');
     hotspot.setAttribute('slot', hotspotName);
     styleForHotspot(hotspot);
+    applyImage(hotspot);
 
     if (showAnnotation) {
       const annotation = document.createElement('div');
@@ -598,6 +638,49 @@ function blinkHotspot(id) {
   }
 }
 
+function captureCameraData() {
+  const modelViewer = document.querySelector('model-viewer');
+  if (!modelViewer) {
+    return null;
+  }
+
+  const orbit = modelViewer.getCameraOrbit();
+  const target = modelViewer.getCameraTarget();
+  const fieldOfView = modelViewer.getFieldOfView();
+
+  if (orbit && target) {
+    return {
+      orbit,
+      target,
+      fieldOfView,
+      type: `${orbit.theta.toFixed(4)}, ${orbit.phi.toFixed(
+        4,
+      )}, ${orbit.radius.toFixed(4)}`,
+    };
+  }
+  return null;
+}
+
+/* Apply auto-rotation from the action override when set, otherwise from the
+   property. The override lets the start/stop actions survive an onUpdate
+   without the rotation silently resuming. */
+function applyAutoRotate() {
+  const modelViewer = document.querySelector('model-viewer');
+  if (!modelViewer) {
+    return;
+  }
+
+  const enabled =
+    autoRotateOverride !== null ? autoRotateOverride : !!properties.autoRotate;
+
+  if (enabled) {
+    modelViewer.setAttribute('auto-rotate', true);
+    modelViewer.setAttribute('auto-rotate-delay', properties.autoRotateDelay);
+  } else {
+    modelViewer.removeAttribute('auto-rotate');
+  }
+}
+
 PandaBridge.init(() => {
   PandaBridge.onLoad((pandaData) => {
     properties = pandaData.properties;
@@ -625,24 +708,7 @@ PandaBridge.init(() => {
 
   /* Markers */
 
-  PandaBridge.getSnapshotData(() => {
-    const modelViewer = document.querySelector('model-viewer');
-    const orbit = modelViewer.getCameraOrbit();
-    const target = modelViewer.getCameraTarget();
-    const fieldOfView = modelViewer.getFieldOfView();
-
-    if (orbit && target) {
-      return {
-        orbit,
-        target,
-        fieldOfView,
-        type: `${orbit.theta.toFixed(4)}, ${orbit.phi.toFixed(
-          4,
-        )}, ${orbit.radius.toFixed(4)}`,
-      };
-    }
-    return null;
-  });
+  PandaBridge.getSnapshotData(() => captureCameraData());
 
   PandaBridge.setSnapshotData((pandaData) => {
     const { isDefault, interpolationDecay } = pandaData.params || {};
@@ -654,6 +720,7 @@ PandaBridge.init(() => {
         lastMarker = id;
       }
     } else {
+      selectedCameraMarkerId = id;
       goToMarker(
         pandaData.data,
         !isDefault && !properties.animateMarkers,
@@ -661,6 +728,29 @@ PandaBridge.init(() => {
         interpolationDecay,
       );
     }
+  });
+
+  /* Re-capture the current camera view into the selected camera marker, driven
+     by the in-panel "Update" editorControl button. Mirrors the 360 component. */
+  PandaBridge.listen('updateCameraMarker', (args) => {
+    const id = (Array.isArray(args) ? args[0] : args) || selectedCameraMarkerId;
+    if (!id) {
+      return;
+    }
+
+    const data = captureCameraData();
+    if (!data) {
+      return;
+    }
+
+    const updated = { id, ...data };
+    const index = (markers || []).findIndex((m) => String(m.id) === String(id));
+    if (index >= 0) {
+      markers[index] = { ...markers[index], ...updated };
+    }
+
+    /* Don't pass an array for updating only the existing marker */
+    PandaBridge.send(PandaBridge.UPDATED, { markers: updated });
   });
 
   /* Actions */
@@ -694,6 +784,16 @@ PandaBridge.init(() => {
   PandaBridge.listen('recenter', () => {
     const modelViewer = document.querySelector('model-viewer');
     modelViewer.cameraTarget = 'auto auto auto';
+  });
+
+  PandaBridge.listen('startAutoRotate', () => {
+    autoRotateOverride = true;
+    applyAutoRotate();
+  });
+
+  PandaBridge.listen('stopAutoRotate', () => {
+    autoRotateOverride = false;
+    applyAutoRotate();
   });
 
   PandaBridge.synchronize('synchroMarkers', (percent) => {


### PR DESCRIPTION
## Summary

Three independent enhancements to the 3D component — two driven by a user (David) request (auto-rotate control + custom hotspot images), one inspired by the 360 component (camera marker update).

### 1. Camera marker "Update" button
An `editorControl` button on camera markers re-captures the current camera view (orbit / target / field-of-view) into the selected marker — no more delete-and-recreate to re-frame a saved position. Mirrors the 360 component's `updateViewpoint`. Factors the capture into `captureCameraData()` (shared with `getSnapshotData`) and tracks the selected marker id via `setSnapshotData`.

### 2. Auto-rotate actions
Two actions — **Start auto-rotate** / **Stop auto-rotate** — toggle model-viewer's `auto-rotate`. A runtime `autoRotateOverride` flag makes the action state survive `onUpdate`, so the rotation no longer silently resumes after being stopped (the core pain point). Named distinctly from the animation Play/Pause actions to avoid confusion.

### 3. Image hotspots
A new `Image` marker param renders a custom image (e.g. a logo) in place of the colored dot. The `<img>` sizes itself (width = marker size, height auto), so the aspect ratio is preserved with no preload — simpler than the 360's Photo-Sphere-Viewer approach. `color` hides when an image is set; clearing the image reverts to the dot. Validated against the model-viewer hotspots/annotations docs.

## Testing
- ✅ Manifest JSON valid, `yarn build` passes, all three features present in the built bundle + manifest.
- ⏳ **Runtime behavior to be validated in the PandaSuite Studio** — the editorControl button, the actions, and image rendering need the Studio host to exercise; they can't be tested headless.

## Notes
- Image hotspots depend on authoring-side "Image marker param" support being live in production Studio.
- Build artifacts (`/build`, `pandasuite-component.zip`) are gitignored and regenerated at release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
